### PR TITLE
Update openapi.yaml

### DIFF
--- a/openapi.yaml
+++ b/openapi.yaml
@@ -9,7 +9,7 @@ info:
     url: "https://redocly.com/docs/cli/"
   license:
     name: MIT
-    url: "https://opensource.org/license/mit/ "
+    url: "https://opensource.org/license/mit/"
 servers:
   - url: "https://api.fake-museum-example.com/v1.1"
 paths:


### PR DESCRIPTION
https://nestia.io/docs/editor/

Tried to convert your `openapi.yaml` to TypeScript SDK, and failed due to type assertion. The type assertion error message was ``info.license.url` is not following the `uri` format, and found that the property value was a little bit weird. The `url` value must be trimmed without any space.

This PR fixes the spaced `url` value, so that succeeded to convert to the TypeScript SDK like below.

- https://stackblitz.com/edit/pqln74?file=README.md,test%2Fstart.ts&startScript=swagger&startScript=hello

```bash
Error on typia.assert(): invalid type on $input.info.license.url, expect to be string & Format<"uri">
```