### PR TITLE
Add delete ticket endpoint

### DIFF
--- a/openapi.yaml
+++ b/openapi.yaml
@@ -204,6 +204,8 @@ paths:
       operationId: deleteTicket
       tags:
         - Tickets
+      parameters:
+        - $ref: "#/components/parameters/EventId"
       responses:
         "204":
           description: Success - ticket deleted.

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -204,11 +204,6 @@ paths:
       operationId: deleteTicket
       tags:
         - Tickets
-      parameters:
-        - $ref: "#/components/parameters/TicketId"
-          decorators:
-            operation-description-override:
-              filePath: ./my-custom-delete-ticket-description.md
       responses:
         "204":
           description: Success - ticket deleted.

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -198,6 +198,24 @@ paths:
           $ref: '#/components/responses/BadRequest'
         "404":
           $ref: '#/components/responses/NotFound'
+    delete:
+      summary: Delete ticket
+      description: Delete ticket and refund. Allows for ticket cancellation.
+      operationId: deleteTicket
+      tags:
+        - Tickets
+      parameters:
+        - $ref: "#/components/parameters/TicketId"
+          decorators:
+            operation-description-override:
+              filePath: ./my-custom-delete-ticket-description.md
+      responses:
+        "204":
+          description: Success - ticket deleted.
+        "400":
+          $ref: '#/components/responses/BadRequest'
+        "404":
+          $ref: '#/components/responses/NotFound'
   /tickets/{ticketId}/qr:
     get:
       summary: Get ticket QR code
@@ -674,7 +692,7 @@ components:
     TicketId:
       name: ticketId
       in: path
-      description: Identifier for a ticket to a museum event. Used to generate ticket image.
+      description: Identifier for a ticket to a museum event.
       required: true
       schema:
         type: string


### PR DESCRIPTION
## What/Why/How?
If a customer needs to cancel their ticket for a refund, this API endpoint can be used to look up the ticket by ID and delete it.

Also makes TicketID description less overly-specific so it works for different endpoints.

## Reference

## Testing

## Screenshots (optional)

## Check yourself

- [x] Code is linted
- [ ] Tested with redoc/reference-docs/workflows (internal)
- [ ] All new/updated code is covered with tests

## Security

- [ ] Security impact of change has been considered
- [ ] Code follows company security practices and guidelines