### PR TITLE
Add linting with annotations to CI

### DIFF
--- a/.github/workflows/museum-lint.yml
+++ b/.github/workflows/museum-lint.yml
@@ -6,14 +6,12 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-    - name: Checkout
-      uses: actions/checkout@v4
-    - name: Setup node
-      uses: actions/setup-node@v3
-      with:
-        node-version: 20.5.1
-        cache: 'npm'
-    - name: Install dependencies
-      run: npm install
-    - name: Run Redocly CLI linting
-      run: npm run lint
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Set up node
+        uses: actions/setup-node@v4
+      - name: Install Redocly CLI
+        run: npm install -g @redocly/cli@latest
+      - name: Run linting
+        run: redocly lint --format=github-actions
+


### PR DESCRIPTION
## What/Why/How?

Redocly CLI recently added support for annotating API descriptions with the result of linting. This pull request adds it for this project.

## Check yourself

- [x] Code is linted
- [x] Tested with redoc/reference-docs/workflows (internal)
- [x] All new/updated code is covered with tests

## Security

- [x] Security impact of change has been considered
- [x] Code follows company security practices and guidelines