### PR TITLE
Some objects didn't have a clear type described

### DIFF
--- a/openapi.yaml
+++ b/openapi.yaml
@@ -356,6 +356,7 @@ components:
       example: 25
     CreateSpecialEventRequest:
       description: Request payload for creating new special events at the museum.
+      type: object
       properties:
         name:
           $ref: "#/components/schemas/EventName"
@@ -375,6 +376,7 @@ components:
         - price
     UpdateSpecialEventRequest:
       description: Request payload for updating an existing special event. Only included fields are updated in the event.
+      type: object
       properties:
         name:
           $ref: "#/components/schemas/EventName"
@@ -393,6 +395,7 @@ components:
         $ref: "#/components/schemas/SpecialEventResponse"
     SpecialEventResponse:
       description: Information about a special event.
+      type: object
       properties:
         eventId:
           $ref: "#/components/schemas/EventId"


### PR DESCRIPTION
## What/Why/How?

While evaluating https://github.com/Redocly/redocly-cli-cookbook/pull/33 I realised that our own API description didn't have types on all components. Added the ones that the check picked up.

## Check yourself

- [x] Code is linted
- [x] Tested with redoc/reference-docs/workflows (internal)
- [x] All new/updated code is covered with tests

## Security

- [x] Security impact of change has been considered
- [x] Code follows company security practices and guidelines