### PR TITLE
Add a landing page to use when rendered as a documentation project

### DIFF
--- a/index.md
+++ b/index.md
@@ -1,0 +1,34 @@
+# Museum API project
+
+The Museum API is a sample API that you can use to try out new API tools, to learn more about OpenAPI, or whatever else you need.
+The [OpenAPI description](./openapi.yaml) is available [on GitHub](https://github.com/Redocly/museum-openapi-example).
+When a new version is released, the API `info.version` field is updated, so check that value when things change.
+
+## `openapi.yaml`
+
+The API description can be found in `openapi.yaml`.
+You can download it and use it as you wish.
+
+## Use Redocly CLI
+
+[Redocly CLI](https://github.com/Redocly/redocly-cli) is an open source CLI utility for all things OpenAPI.
+Try Redocly CLI to get to grips with some of the different things you can do with OpenAPI.
+
+- Use `stats` to assess an API: `redocly stats openapi.yaml`.
+- Run `lint` to observe if an OpenAPI is compatible with a set of standards: `redocly lint openapi.yaml`.
+- View API reference documentation: `redocly preview-docs openapi.yaml`.
+
+The [Redocly CLI documentation](https://redocly.com/docs/cli/) has all the information you need to dive into more detail on any of these common tasks, and of course many more!
+
+## Build an API experience
+
+A key part of great API experience is great documentation.
+Taking the API reference as the heart of the experience, Redocly's platform goes much further and includes a full documentation platform.
+
+Run `redocly preview` to run your project locally, and start adding content.
+Or use the cloud editor with immediate preview and collaborative editing.
+
+Write great content with great tools; Redocly supports [Markdoc](https://markdoc.dev/), a modern extension to Markdown.
+(We use it ourselves and love it!)
+If you're new to Markdown, visit our [Markdoc learning hub](https://redocly.com/docs/learn-markdoc/) to get started.
+

--- a/redocly.yaml
+++ b/redocly.yaml
@@ -22,3 +22,6 @@ rules:
     message: "Example summary must be sentence cased."
     assertions: 
       pattern: /^[A-Z]+[^A-Z]+$/
+
+ignore:
+  - .github


### PR DESCRIPTION
## What/Why/How?

We use the Museum API with so many of our tools, this pull request adds a home page that is used when it's rendered as documentation, giving the use an entry point, some ideas, and linking to some next steps.

## Check yourself

- [x] Code is linted
- [x] Tested with redoc/reference-docs/workflows (internal)
- [x] All new/updated code is covered with tests

## Security

- [x] Security impact of change has been considered
- [x] Code follows company security practices and guidelines