### PR TITLE
Refactor: Uncouple from HTTP and use data models

### DIFF
--- a/openapi.yaml
+++ b/openapi.yaml
@@ -30,7 +30,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/GetMuseumHoursResponse"
+                $ref: "#/components/schemas/MuseumHoursCollection"
               examples:
                 default_example:
                   $ref: "#/components/examples/GetMuseumHoursResponseExample"
@@ -50,7 +50,7 @@ paths:
         content:
           application/json:
             schema:
-              $ref: "#/components/schemas/CreateSpecialEventRequest"
+              $ref: "#/components/schemas/SpecialEvent"
             examples:
               default_example:
                 $ref: "#/components/examples/CreateSpecialEventRequestExample"
@@ -60,7 +60,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/SpecialEventResponse"
+                $ref: "#/components/schemas/SpecialEvent"
               examples:
                 default_example:
                   $ref: "#/components/examples/CreateSpecialEventResponseExample"
@@ -85,7 +85,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/ListSpecialEventsResponse"
+                $ref: "#/components/schemas/SpecialEventCollection"
               examples:
                 default_example:
                   $ref: "#/components/examples/ListSpecialEventsResponseExample"
@@ -108,7 +108,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/SpecialEventResponse"
+                $ref: "#/components/schemas/SpecialEvent"
               examples:
                 default_example:
                   $ref: "#/components/examples/GetSpecialEventResponseExample"
@@ -129,7 +129,7 @@ paths:
         content:
           application/json:
             schema:
-              $ref: "#/components/schemas/UpdateSpecialEventRequest"
+              $ref: "#/components/schemas/SpecialEvent"
             examples:
               default_example:
                 $ref: "#/components/examples/UpdateSpecialEventRequestExample"
@@ -139,7 +139,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/SpecialEventResponse"
+                $ref: "#/components/schemas/SpecialEvent"
               examples:
                 default_example:
                   $ref: "#/components/examples/UpdateSpecialEventResponseExample"
@@ -176,7 +176,7 @@ paths:
         content:
           application/json:
             schema:
-              $ref: "#/components/schemas/BuyMuseumTicketsRequest"
+              $ref: "#/components/schemas/BuyMuseumTickets"
             examples:
               general_entry:
                 $ref: "#/components/examples/BuyGeneralTicketsRequestExample"
@@ -188,7 +188,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/BuyMuseumTicketsResponse"
+                $ref: "#/components/schemas/MuseumTicketsConfirmation"
               examples:
                 general_entry:
                   $ref: "#/components/examples/BuyGeneralTicketsResponseExample"
@@ -213,7 +213,7 @@ paths:
           content:
             image/png:
               schema:
-                $ref: "#/components/schemas/GetTicketCodeResponse"
+                $ref: "#/components/schemas/TicketCodeImage"
         "400":
           $ref: '#/components/responses/BadRequest'
         "404":
@@ -236,30 +236,11 @@ components:
       type: string
       format: email
       example: museum-lover@example.com
-    Phone:
-      description: Phone number for the ticket purchaser (optional).
-      type: string
-      example: '+1(234)-567-8910'
-    BuyMuseumTicketsRequest:
-      description: Request payload used for purchasing museum tickets.
-      type: object
-      properties:
-        ticketType:
-          $ref: "#/components/schemas/TicketType"
-        eventId:
-          description: Unique identifier for a special event. Required if purchasing tickets for the museum's special events.
-          $ref: "#/components/schemas/EventId"
-        ticketDate:
-          description: Date that the ticket is valid for.
-          $ref: "#/components/schemas/Date"
-        email:
-          $ref: "#/components/schemas/Email"
-        phone:
-          $ref: "#/components/schemas/Phone"
-      required:
-        - ticketType
-        - ticketDate
-        - email
+    BuyMuseumTickets:
+      description: Data to purchase a ticket.
+      allOf:
+        - $ref: "#/components/schemas/Ticket"
+        - $ref: "#/components/schemas/Email"
     TicketMessage:
       description: Confirmation message after a ticket purchase.
       type: string
@@ -268,39 +249,48 @@ components:
       description: Unique identifier for museum ticket. Generated when purchased.
       type: string
       format: uuid
+      readOnly: true
       example: a54a57ca-36f8-421b-a6b4-2e8f26858a4c
     TicketConfirmation:
       description: Unique confirmation code used to verify ticket purchase.
       type: string
       example: 'ticket-event-a98c8f-7eb12'
-    BuyMuseumTicketsResponse:
-      description: Details for a museum ticket after a successful purchase.
+    Ticket:
+      description: Ticket for museum entry, can be general admission or special event.
       type: object
       properties:
-        message:
-          $ref: "#/components/schemas/TicketMessage"
-        eventName:
-          $ref: "#/components/schemas/EventName"
         ticketId:
           $ref: "#/components/schemas/TicketId"
-        ticketType:
-          $ref: "#/components/schemas/TicketType"
         ticketDate:
           description: Date the ticket is valid for.
           $ref: "#/components/schemas/Date"
-        confirmationCode:
-          $ref: "#/components/schemas/TicketConfirmation"
+        ticketType:
+          $ref: "#/components/schemas/TicketType"
+        eventId:
+          description: Unique identifier for a special event. Required if purchasing tickets for the museum's special events.
+          $ref: "#/components/schemas/EventId"
       required:
-        - message
         - ticketId
         - ticketType
         - ticketDate
-        - confirmationCode
-    GetTicketCodeResponse:
+    MuseumTicketsConfirmation:
+      description: Details for a museum ticket after a successful purchase.
+      allOf:
+        - $ref: "#/components/schemas/Ticket"
+        - type: object
+          properties:
+            message:
+              $ref: "#/components/schemas/TicketMessage"
+            confirmationCode:
+              $ref: "#/components/schemas/TicketConfirmation"
+          required:
+            - message
+            - confirmationCode
+    TicketCodeImage:
       description: Image of a ticket with a QR code used for museum or event entry.
       type: string
       format: binary
-    GetMuseumHoursResponse:
+    MuseumHoursCollection:
       description: List of museum operating hours for consecutive days.
       type: array
       items:
@@ -332,6 +322,7 @@ components:
       type: string
       format: uuid
       example: 3be6453c-03eb-4357-ae5a-984a0e574a54
+      readOnly: true
     EventName:
       type: string
       description: Name of the special event.
@@ -354,47 +345,7 @@ components:
       type: number
       format: float
       example: 25
-    CreateSpecialEventRequest:
-      description: Request payload for creating new special events at the museum.
-      type: object
-      properties:
-        name:
-          $ref: "#/components/schemas/EventName"
-        location:
-          $ref: "#/components/schemas/EventLocation"
-        eventDescription:
-          $ref: "#/components/schemas/EventDescription"
-        dates:
-          $ref: "#/components/schemas/EventDates"
-        price:
-          $ref: "#/components/schemas/EventPrice"
-      required:
-        - name
-        - location
-        - eventDescription
-        - dates
-        - price
-    UpdateSpecialEventRequest:
-      description: Request payload for updating an existing special event. Only included fields are updated in the event.
-      type: object
-      properties:
-        name:
-          $ref: "#/components/schemas/EventName"
-        location:
-          $ref: "#/components/schemas/EventLocation"
-        eventDescription:
-          $ref: "#/components/schemas/EventDescription"
-        dates:
-          $ref: "#/components/schemas/EventDates"
-        price:
-          $ref: "#/components/schemas/EventPrice"
-    ListSpecialEventsResponse:
-      description: List of upcoming special events.
-      type: array
-      items:
-        $ref: "#/components/schemas/SpecialEventResponse"
-    SpecialEventResponse:
-      description: Information about a special event.
+    SpecialEvent:
       type: object
       properties:
         eventId:
@@ -410,12 +361,16 @@ components:
         price:
           $ref: "#/components/schemas/EventPrice"
       required:
-        - eventId
         - name
         - location
         - eventDescription
         - dates
         - price
+    SpecialEventCollection:
+      description: List of upcoming special events.
+      type: array
+      items:
+        $ref: "#/components/schemas/SpecialEvent"
     Error:
       type: object
       properties:

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -129,7 +129,7 @@ paths:
         content:
           application/json:
             schema:
-              $ref: "#/components/schemas/SpecialEvent"
+              $ref: "#/components/schemas/SpecialEventFields"
             examples:
               default_example:
                 $ref: "#/components/examples/UpdateSpecialEventRequestExample"
@@ -238,9 +238,13 @@ components:
       example: museum-lover@example.com
     BuyMuseumTickets:
       description: Data to purchase a ticket.
+      type: object
       allOf:
+        - type: object
+          properties:
+            email:
+              $ref: "#/components/schemas/Email"
         - $ref: "#/components/schemas/Ticket"
-        - $ref: "#/components/schemas/Email"
     TicketMessage:
       description: Confirmation message after a ticket purchase.
       type: string
@@ -342,6 +346,19 @@ components:
       type: number
       format: float
       example: 25
+    SpecialEventFields:
+      type: object
+      properties:
+        name:
+          $ref: "#/components/schemas/EventName"
+        location:
+          $ref: "#/components/schemas/EventLocation"
+        eventDescription:
+          $ref: "#/components/schemas/EventDescription"
+        dates:
+          $ref: "#/components/schemas/EventDates"
+        price:
+          $ref: "#/components/schemas/EventPrice"
     SpecialEvent:
       type: object
       properties:
@@ -392,7 +409,7 @@ components:
     BuyEventTicketsRequestExample:
       summary: Special event ticket
       value:
-        ticketType: general
+        ticketType: event
         eventId: dad4bce8-f5cb-4078-a211-995864315e39
         ticketDate: '2023-09-05'
         email: todd@example.com

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -2,7 +2,7 @@ openapi: 3.1.0
 info:
   title: Redocly Museum API
   description: Imaginary, but delightful Museum API for interacting with museum services and information. Built with love by Redocly.
-  version: 1.1.1
+  version: 1.2.0
   termsOfService: 'https://redocly.com/subscription-agreement/'
   contact:
     email: team@redocly.com
@@ -30,7 +30,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/MuseumHoursCollection"
+                $ref: "#/components/schemas/MuseumHours"
               examples:
                 default_example:
                   $ref: "#/components/examples/GetMuseumHoursResponseExample"
@@ -249,7 +249,6 @@ components:
       description: Unique identifier for museum ticket. Generated when purchased.
       type: string
       format: uuid
-      readOnly: true
       example: a54a57ca-36f8-421b-a6b4-2e8f26858a4c
     TicketConfirmation:
       description: Unique confirmation code used to verify ticket purchase.
@@ -270,7 +269,6 @@ components:
           description: Unique identifier for a special event. Required if purchasing tickets for the museum's special events.
           $ref: "#/components/schemas/EventId"
       required:
-        - ticketId
         - ticketType
         - ticketDate
     MuseumTicketsConfirmation:
@@ -290,8 +288,8 @@ components:
       description: Image of a ticket with a QR code used for museum or event entry.
       type: string
       format: binary
-    MuseumHoursCollection:
-      description: List of museum operating hours for consecutive days.
+    MuseumHours:
+      description: List of museum operating hours for a date range.
       type: array
       items:
         $ref: "#/components/schemas/MuseumDailyHours"
@@ -322,7 +320,6 @@ components:
       type: string
       format: uuid
       example: 3be6453c-03eb-4357-ae5a-984a0e574a54
-      readOnly: true
     EventName:
       type: string
       description: Name of the special event.

--- a/redocly.yaml
+++ b/redocly.yaml
@@ -6,7 +6,7 @@ extends:
 rules: 
   operation-tag-defined: error
   no-invalid-schema-examples: error
-  no-invalid-media-type-examples: error
+  no-invalid-media-type-examples: off # Check support for readOnly fields
   scalar-property-missing-example: error
   rule/operation-summary-sentence-case:
     subject: 

--- a/redocly.yaml
+++ b/redocly.yaml
@@ -6,7 +6,9 @@ extends:
 rules: 
   operation-tag-defined: error
   no-invalid-schema-examples: error
-  no-invalid-media-type-examples: off # Check support for readOnly fields
+  no-invalid-media-type-examples:
+    severity: error
+    allowAdditionalProperties: true
   scalar-property-missing-example: error
   rule/operation-summary-sentence-case:
     subject: 


### PR DESCRIPTION
## What/Why/How?

When we created the Museum API, we stopped iterating at the HTTP data transfer level. This PR doesn't change much of the API description (removed phone numbers from ticket records) but takes a more RESTful approach of modelling entities.

Still needs work: since the ID fields are readonly, I ran into https://github.com/Redocly/redocly-cli/issues/1416 which marks the examples as invalid.

## Check yourself

- [x] Code is linted
- [ ] Tested with redoc/reference-docs/workflows (internal)
- [ ] All new/updated code is covered with tests

## Security

- [x] Security impact of change has been considered
- [x] Code follows company security practices and guidelines