### PR TITLE
chore: update jsonpath to be valid

### DIFF
--- a/arazzo/museum-api.arazzo.yaml
+++ b/arazzo/museum-api.arazzo.yaml
@@ -68,7 +68,9 @@ workflows:
           - condition: $statusCode == 201
           - context: $response.body
             condition: $.name == 'Mermaid Treasure Identification and Analysis'
-            type: jsonpath
+            type:
+              type: jsonpath
+              version: draft-goessner-dispatch-jsonpath-00
         outputs:
           createdEventId: $response.body.eventId
           name: $response.body.name
@@ -104,7 +106,9 @@ workflows:
           - condition: $statusCode == 200
           - context: $response.body
             condition: $.name == 'Orca Identification and Analysis'
-            type: jsonpath
+            type:
+              type: jsonpath
+              version: draft-goessner-dispatch-jsonpath-00
         outputs:
           updatedEventId: $response.body.eventId
       - stepId: delete-event


### PR DESCRIPTION
## What/Why/How?
As we already have type validation in CLI and type for jsonPath criteria is align - we need to update it here as well.

```
            "allOf": [
                {
                    "if": {
                        "required": [
                            "type"
                        ],
                        "properties": {
                            "type": {
                                "const": "jsonpath"
                            }
                        }
                    },
                    "then": {
                        "properties": {
                            "version": {
                                "const": "draft-goessner-dispatch-jsonpath-00"
                            }
                        }
                    }
                },
```

Or out simplified version:
```
const JSONPathCriterion: NodeType = {
  properties: {
    type: { type: 'string', enum: ['jsonpath'] },
    version: { type: 'string', enum: ['draft-goessner-dispatch-jsonpath-00'] },
  },
};
```
## Reference

DependsOn:
- https://github.com/Redocly/redocly/pull/10680

## Testing

## Screenshots (optional)

## Check yourself

- [ ] Code is linted
- [ ] Tested with redoc/reference-docs/workflows (internal)
- [ ] All new/updated code is covered with tests

## Security

- [x] Security impact of change has been considered
- [x] Code follows company security practices and guidelines