### PR TITLE
chore: update preview shortcut to use the preview command

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "main": "index.js",
   "scripts": {
     "lint": "npx @redocly/cli@latest lint",
-    "preview": "npx @redocly/cli preview-docs"
+    "preview": "npx @redocly/cli preview"
   },
   "keywords": [
     "OpenAPI",


### PR DESCRIPTION
## What/Why/How?

The preview command uses the newest Redoc product instead of the previous generations.

## Reference

We've received emails asking similar issues into support.

## Testing

n/a

## Screenshots (optional)

## Check yourself

- [ ] Code is linted
- [ ] Tested with redoc/reference-docs/workflows (internal)
- [ ] All new/updated code is covered with tests

## Security

- [x] Security impact of change has been considered
- [x] Code follows company security practices and guidelines