### PR TITLE
Add a webhook to the Museum example

### DIFF
--- a/openapi.yaml
+++ b/openapi.yaml
@@ -218,6 +218,26 @@ paths:
           $ref: '#/components/responses/BadRequest'
         "404":
           $ref: '#/components/responses/NotFound'
+webhooks:
+  publishNewEvent:
+    post:
+      summary: New special event added
+      description: Publish details of a new or updated event.
+      operationId: publishNewEvent
+      tags:
+        - Events
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/SpecialEvent"
+            examples:
+              default_example:
+                $ref: "#/components/examples/GetSpecialEventResponseExample"
+      responses:
+        "202":
+          description: Data accepted.
+
 components:
   schemas:
     TicketType:


### PR DESCRIPTION
## What/Why/How?

We don't currently have any webhooks in the Museum API and it would be cool to include one!

## Check yourself

- [x] Code is linted
- [ ] Tested with redoc/reference-docs/workflows (internal)
- [x] All new/updated code is covered with tests

## Security

- [x] Security impact of change has been considered
- [x] Code follows company security practices and guidelines